### PR TITLE
image_to_guess#16

### DIFF
--- a/sass/components/_image.scss
+++ b/sass/components/_image.scss
@@ -1,0 +1,9 @@
+.swquiz-app-image {
+	background-repeat: no-repeat;
+    background-size: cover;
+    background-position: top;
+    width: 400px;
+    height: 600px;
+    box-shadow: 0 4px 4px rgba(0,0,0,.25), 4px 4px 40px rgba(255,0,0,.9);
+    border-radius: 16px;
+}

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -7,7 +7,7 @@
 
 // * COMPONENTY
 @import 'components/btn';
-
+@import 'components/image';
 // * LAYOUTS
 @import 'layouts/example';
 

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,4 +1,8 @@
+import {showImage} from './showImage';
+
 export const App = ({options}) => {
+
+	showImage('c3RhdGljL2Fzc2V0cy9pbWcvbW9kZXMvcGVvcGxlLzQuanBn');
 }
 
 

--- a/src/app/showImage.js
+++ b/src/app/showImage.js
@@ -1,0 +1,15 @@
+export const showImage = (image)=> {
+	
+	const app = document.getElementById('swquiz-app')
+	const imageWrapper = document.createElement('div');
+
+	image = atob(image)
+
+	imageWrapper.classList.add('swquiz-app-image');
+	imageWrapper.style.backgroundImage = `url(${image})`;
+	app.appendChild(imageWrapper);
+}
+
+
+	
+

--- a/src/app/showImage.js
+++ b/src/app/showImage.js
@@ -1,13 +1,14 @@
-export const showImage = (image)=> {
+export const showImage = (image) => {
 	
 	const app = document.getElementById('swquiz-app')
 	const imageWrapper = document.createElement('div');
 
 	image = atob(image)
-
+imageWrapper.setAttribute('data-testid', 'imageWrapper');
 	imageWrapper.classList.add('swquiz-app-image');
 	imageWrapper.style.backgroundImage = `url(${image})`;
 	app.appendChild(imageWrapper);
+	
 }
 
 

--- a/test/showImage.spec.js
+++ b/test/showImage.spec.js
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/dom'
 import '@testing-library/jest-dom/extend-expect';
-import {showImage} from './showImage';
+import {showImage} from '../src/app/showImage';
 
 test('should add imageWrapper element to DOM and have swquiz-app-image calss', () => {
 

--- a/test/showImage.spec.js
+++ b/test/showImage.spec.js
@@ -1,0 +1,22 @@
+import { screen } from '@testing-library/dom'
+import '@testing-library/jest-dom/extend-expect';
+import {showImage} from './showImage';
+
+test('should add imageWrapper element to DOM and have swquiz-app-image calss', () => {
+
+document.body.innerHTML = `
+<div id="swquiz-app">
+</div>
+`
+
+showImage('c3RhdGljL2Fzc2V0cy9pbWcvbW9kZXMvcGVvcGxlLzQuanBn');
+
+const convertFromBas64 = atob('c3RhdGljL2Fzc2V0cy9pbWcvbW9kZXMvcGVvcGxlLzQuanBn');
+
+expect(screen.getByTestId('imageWrapper')).toBeEmptyDOMElement()
+expect(screen.getByTestId('imageWrapper')).toHaveClass('swquiz-app-image')
+expect(screen.getByTestId('imageWrapper')).toHaveStyle(`
+  background-image: url('${convertFromBas64}');
+`)
+expect(screen.getByTestId('imageWrapper')).toBeInstanceOf(HTMLElement)
+})


### PR DESCRIPTION
Stworzyłem funkcję które generuję element DOM i nadaje mu odpowiednią klasę zdefiniowaną w sass/component
Element który będzie należało poprawić to wysokość oraz szerokość tego elementy gdyż aktualnie wyrażone są one w px, natomiast powinny być w jednostkach względnych. 
Ze względu na to, że jednostki względne odnoszą się do rodzica to nie mogę ich zastosować (nie mając rodzica)... 
uf... trudne jest takie "abstrakcyjne" pisanie kodu..

Chciałem napisać jakiś test, jednak google twierdzi że aby testować elementy DOM potrzebuję enzyme, a ja i bez dodatkowych paczek gubię się w testowaniu 