### PR TITLE
#28 Logika | Zapisywanie rankingu w Local Storage

### DIFF
--- a/src/app/Ranking.js
+++ b/src/app/Ranking.js
@@ -1,13 +1,29 @@
 export class Ranking {
     constructor(mode) {
-        const modes = ['people', 'starships', 'vehicles'];
-        if (modes.includes(mode)) {
-            this.mode = mode;
-        } else {
-            throw `"${mode}" mode is not valid!`;
-        }
+        const availableModes = ['people', 'starships', 'vehicles'];
+        if (!availableModes.includes(mode)) throw `"${mode}" mode is not valid!`;
+        this.mode = mode;
     }
 
+    saveScore(user, score, maxScore) {
+        if (this._isLessThanThreeResults()) {
+            const topResults = JSON.parse(localStorage.getItem(this.mode));
+            topResults.push({
+                user,
+                score,
+                maxScore
+            });
+            localStorage.setItem(this.mode, JSON.stringify(topResults));
+        } else if (this._isHigherThanCurrentTop(score, maxScore)) {
+            const topResults = this._getTwoHighestResults();
+            topResults.push({
+                user,
+                score,
+                maxScore
+            });
+            localStorage.setItem(this.mode, JSON.stringify(topResults));
+        }
+    }
     _isLessThanThreeResults() {
         let results = localStorage.getItem(this.mode);
         if (!results) {
@@ -30,27 +46,12 @@ export class Ranking {
         return topResults.filter((result, i) => i !== totalScores.indexOf(Math.min(...totalScores)));
     }
 
-    saveScore(user, score, maxScore) {
-        if (this._isLessThanThreeResults()) {
-            const topResults = JSON.parse(localStorage.getItem(this.mode));
-            topResults.push({
-                'user': user,
-                'score': score,
-                'maxScore': maxScore
-            });
-            localStorage.setItem(this.mode, JSON.stringify(topResults));
-        } else if (this._isHigherThanCurrentTop(score, maxScore)) {
-            const topResults = this._getTwoHighestResults();
-            topResults.push({
-                'user': user,
-                'score': score,
-                'maxScore': maxScore
-            });
-            localStorage.setItem(this.mode, JSON.stringify(topResults));
-        }
-    }
-
-    showRanking() {
-        return JSON.parse(localStorage.getItem(this.mode));
+    getScores() {
+        let results = localStorage.getItem(this.mode);
+        if (!results) {
+            localStorage.setItem(this.mode, JSON.stringify([]));
+            results = localStorage.getItem(this.mode);
+        };
+        return JSON.parse(results);
     }
 }

--- a/src/app/Ranking.js
+++ b/src/app/Ranking.js
@@ -1,57 +1,50 @@
 export class Ranking {
-    constructor(mode) {
-        const availableModes = ['people', 'starships', 'vehicles'];
-        if (!availableModes.includes(mode)) throw `"${mode}" mode is not valid!`;
-        this.mode = mode;
-    }
+  constructor(mode) {
+    const availableModes = ['people', 'starships', 'vehicles'];
+    if (!availableModes.includes(mode)) throw `"${mode}" mode is not valid!`;
+    this.mode = mode;
+  }
 
-    saveScore(user, score, maxScore) {
-        if (this._isLessThanThreeResults()) {
-            const topResults = JSON.parse(localStorage.getItem(this.mode));
-            topResults.push({
-                user,
-                score,
-                maxScore
-            });
-            localStorage.setItem(this.mode, JSON.stringify(topResults));
-        } else if (this._isHigherThanCurrentTop(score, maxScore)) {
-            const topResults = this._getTwoHighestResults();
-            topResults.push({
-                user,
-                score,
-                maxScore
-            });
-            localStorage.setItem(this.mode, JSON.stringify(topResults));
-        }
+  saveScore(user, score, maxScore) {
+    if (this._isLessThanThreeResults()) {
+      const topResults = JSON.parse(localStorage.getItem(this.mode));
+      topResults.push({ user, score, maxScore });
+      localStorage.setItem(this.mode, JSON.stringify(topResults));
+    } else if (this._isHigherThanCurrentTop(score, maxScore)) {
+      const topResults = this._getTwoHighestResults();
+      topResults.push({ user, score, maxScore });
+      localStorage.setItem(this.mode, JSON.stringify(topResults));
     }
-    _isLessThanThreeResults() {
-        let results = localStorage.getItem(this.mode);
-        if (!results) {
-            localStorage.setItem(this.mode, JSON.stringify([]));
-            results = localStorage.getItem(this.mode);
-        };
-        const numOfResults = JSON.parse(results).length;
-        return numOfResults < 3;
+  }
+  _isLessThanThreeResults() {
+    let results = localStorage.getItem(this.mode);
+    if (!results) {
+      localStorage.setItem(this.mode, JSON.stringify([]));
+      results = localStorage.getItem(this.mode);
     }
+    const numOfResults = JSON.parse(results).length;
+    return numOfResults < 3;
+  }
 
-    _isHigherThanCurrentTop(score, maxScore) {
-        const topResults = JSON.parse(localStorage.getItem(this.mode));
-        const totalScores = topResults.map(result => result['score'] / result['maxScore']);
-        return score / maxScore >= Math.min(...totalScores);
-    }
+  _isHigherThanCurrentTop(score, maxScore) {
+    const topResults = JSON.parse(localStorage.getItem(this.mode));
+    const totalScores = topResults.map(
+      (result) => result['score'] / result['maxScore'],
+    );
+    return score / maxScore >= Math.min(...totalScores);
+  }
 
-    _getTwoHighestResults() {
-        const topResults = JSON.parse(localStorage.getItem(this.mode));
-        const totalScores = topResults.map(result => result['score'] / result['maxScore']);
-        return topResults.filter((result, i) => i !== totalScores.indexOf(Math.min(...totalScores)));
-    }
+  _getTwoHighestResults() {
+    const topResults = JSON.parse(localStorage.getItem(this.mode));
+    const totalScores = topResults.map(
+      (result) => result['score'] / result['maxScore'],
+    );
+    return topResults.filter(
+      (result, i) => i !== totalScores.indexOf(Math.min(...totalScores)),
+    );
+  }
 
-    getScores() {
-        let results = localStorage.getItem(this.mode);
-        if (!results) {
-            localStorage.setItem(this.mode, JSON.stringify([]));
-            results = localStorage.getItem(this.mode);
-        };
-        return JSON.parse(results);
-    }
+  getScores() {
+    return JSON.parse(localStorage.getItem(this.mode)) ?? [];
+  }
 }

--- a/src/app/Ranking.js
+++ b/src/app/Ranking.js
@@ -1,0 +1,56 @@
+export class Ranking {
+    constructor(mode) {
+        const modes = ['people', 'starships', 'vehicles'];
+        if (modes.includes(mode)) {
+            this.mode = mode;
+        } else {
+            throw `"${mode}" mode is not valid!`;
+        }
+    }
+
+    _isLessThanThreeResults() {
+        let results = localStorage.getItem(this.mode);
+        if (!results) {
+            localStorage.setItem(this.mode, JSON.stringify([]));
+            results = localStorage.getItem(this.mode);
+        };
+        const numOfResults = JSON.parse(results).length;
+        return numOfResults < 3;
+    }
+
+    _isHigherThanCurrentTop(score, maxScore) {
+        const topResults = JSON.parse(localStorage.getItem(this.mode));
+        const totalScores = topResults.map(result => result['score'] / result['maxScore']);
+        return score / maxScore >= Math.min(...totalScores);
+    }
+
+    _getTwoHighestResults() {
+        const topResults = JSON.parse(localStorage.getItem(this.mode));
+        const totalScores = topResults.map(result => result['score'] / result['maxScore']);
+        return topResults.filter((result, i) => i !== totalScores.indexOf(Math.min(...totalScores)));
+    }
+
+    saveScore(user, score, maxScore) {
+        if (this._isLessThanThreeResults()) {
+            const topResults = JSON.parse(localStorage.getItem(this.mode));
+            topResults.push({
+                'user': user,
+                'score': score,
+                'maxScore': maxScore
+            });
+            localStorage.setItem(this.mode, JSON.stringify(topResults));
+        } else if (this._isHigherThanCurrentTop(score, maxScore)) {
+            const topResults = this._getTwoHighestResults();
+            topResults.push({
+                'user': user,
+                'score': score,
+                'maxScore': maxScore
+            });
+            localStorage.setItem(this.mode, JSON.stringify(topResults));
+        }
+    }
+
+    showRanking() {
+        return JSON.parse(localStorage.getItem(this.mode));
+    }
+}

--- a/test/ranking.spec.js
+++ b/test/ranking.spec.js
@@ -23,78 +23,38 @@ describe("Ranking's logic", () => {
         localStorage.clear();
     });
 
-    it('When set wrong category name, exception will be thrown', () => {
+    it('When set wrong category name then exception will be thrown', () => {
         expect(() => {
             new Ranking('vehicle');
         }).toThrow('"vehicle" mode is not valid!');
     });
 
-    it('When new score is higher than or equal to at least one of top results, return true', () => {
-        localStorage.setItem('people', JSON.stringify(results));
-        const score = 9;
-        const maxScore = 18; // 45%
-
-        expect(peopleRanking._isHigherThanCurrentTop(score, maxScore)).toBeTruthy;
-    });
-
-    it('When new score is less than all of top results, return false', () => {
-        localStorage.setItem('people', JSON.stringify(results));
-        const score = 11;
-        const maxScore = 25; // 44%
-
-        expect(peopleRanking._isHigherThanCurrentTop(score, maxScore)).toBeFalsy;
-    });
-
-    it('When there are three results, return two best of them.', () => {
-        localStorage.setItem('people', JSON.stringify(results));
-        const bestResults = [{
-            'user': 'user1',
-            'score': 15,
-            'maxScore': 30 // 50%
-        }, {
-            'user': 'user3',
-            'score': 15,
-            'maxScore': 25 // 60%
-        }];
-
-        expect(peopleRanking._getTwoHighestResults()).toEqual(bestResults);
-    });
-
-    it('When less than three results, add a new result to the top scores', () => {
-        const savedResults = [{
-            'user': 'user',
-            'score': 0,
-            'maxScore': 100
-        }];
-        expect(JSON.parse(localStorage.getItem('people'))).toBeNull;
+    it('When less than three results then add a new result to the top scores', () => {
+        expect(JSON.parse(localStorage.getItem('people'))).toBeNull();
         peopleRanking.saveScore('user', 0, 100);
 
-        expect(JSON.parse(localStorage.getItem('people'))).toEqual(savedResults);
+        expect(JSON.parse(localStorage.getItem('people'))).toEqual(expectedResultsWhenOnlyOne);
     });
 
-    it('When there are three scores and a new one is higher than or equal to any of them, add the new result to the top scores instead of the lowest one', () => {
-        const savedResults = [{
-            'user': 'user1',
-            'score': 15,
-            'maxScore': 30 // 50%
-        }, {
-            'user': 'user3',
-            'score': 15,
-            'maxScore': 25 // 60%
-        }, {
-            'user': 'newUser',
-            'score': 9,
-            'maxScore': 18 // 45%
-        }];
+    it('When there are three scores and a new one is equal to any of them then add the new result to the top scores instead of the lowest one', () => {
         const vehiclesRanking = new Ranking('vehicles');
         localStorage.setItem('vehicles', JSON.stringify(results));
 
         vehiclesRanking.saveScore('newUser', 9, 18); // 45%
 
-        expect(JSON.parse(localStorage.getItem('vehicles'))).toEqual(savedResults);
+        expect(JSON.parse(localStorage.getItem('vehicles'))).toEqual(expectedResultsWhenEqual);
     });
 
-    it('When there are three scores and a new one is less than all of them, do not add it to the top scores', () => {
+    it('When there are three scores and a new one is higher than any of them then add the new result to the top scores instead of the lowest one', () => {
+        const vehiclesRanking = new Ranking('vehicles');
+        localStorage.setItem('vehicles', JSON.stringify(results));
+
+        vehiclesRanking.saveScore('newUser', 1, 1); // 100%
+
+        expect(JSON.parse(localStorage.getItem('vehicles'))).toEqual(expectedResultsWhenHigher);
+    });
+
+    it('When there are three scores and a new one is less than all of them then do not add it to the top scores', () => {
         const starshipsRanking = new Ranking('starships');
         localStorage.setItem('starships', JSON.stringify(results));
 
@@ -103,10 +63,49 @@ describe("Ranking's logic", () => {
         expect(JSON.parse(localStorage.getItem('starships'))).toEqual(results);
     });
 
-    it('Ranking saved in local storage should be shown', () => {
+    it('Ranking saved in local storage should be returned', () => {
         const starshipsRanking = new Ranking('starships');
         localStorage.setItem('starships', JSON.stringify(results));
 
-        expect(starshipsRanking.showRanking()).toEqual(results);
+        expect(starshipsRanking.getScores()).toEqual(results);
     });
+
+    it('When no score is saved in local storage then return an empty array', () => {
+        const starshipsRanking = new Ranking('starships');
+        expect(starshipsRanking.getScores()).toEqual([]);
+    });
+    
+    const expectedResultsWhenOnlyOne = [{
+        'user': 'user',
+        'score': 0,
+        'maxScore': 100
+    }];
+
+    const expectedResultsWhenEqual = [{
+        'user': 'user1',
+        'score': 15,
+        'maxScore': 30 // 50%
+    }, {
+        'user': 'user3',
+        'score': 15,
+        'maxScore': 25 // 60%
+    }, {
+        'user': 'newUser',
+        'score': 9,
+        'maxScore': 18 // 45%
+    }];
+    
+    const expectedResultsWhenHigher = [{
+        'user': 'user1',
+        'score': 15,
+        'maxScore': 30 // 50%
+    }, {
+        'user': 'user3',
+        'score': 15,
+        'maxScore': 25 // 60%
+    }, {
+        'user': 'newUser',
+        'score': 1,
+        'maxScore': 1 // 100%
+    }];
 });

--- a/test/ranking.spec.js
+++ b/test/ranking.spec.js
@@ -1,111 +1,129 @@
-import {
-    Ranking
-} from '../src/app/Ranking';
+import { Ranking } from '../src/app/Ranking';
 
 describe("Ranking's logic", () => {
-    const peopleRanking = new Ranking('people');
+  const peopleRanking = new Ranking('people');
 
-    const results = [{
-        'user': 'user1',
-        'score': 15,
-        'maxScore': 30 // 50%
-    }, {
-        'user': 'user2',
-        'score': 18,
-        'maxScore': 40 // 45%
-    }, {
-        'user': 'user3',
-        'score': 15,
-        'maxScore': 25 // 60%
-    }];
+  const results = [
+    {
+      user: 'user1',
+      score: 15,
+      maxScore: 30, // 50%
+    },
+    {
+      user: 'user2',
+      score: 18,
+      maxScore: 40, // 45%
+    },
+    {
+      user: 'user3',
+      score: 15,
+      maxScore: 25, // 60%
+    },
+  ];
 
-    afterEach(() => {
-        localStorage.clear();
-    });
+  const expectedResultsWhenOnlyOne = [
+    {
+      user: 'user',
+      score: 0,
+      maxScore: 100,
+    },
+  ];
 
-    it('When set wrong category name then exception will be thrown', () => {
-        expect(() => {
-            new Ranking('vehicle');
-        }).toThrow('"vehicle" mode is not valid!');
-    });
+  const expectedResultsWhenEqual = [
+    {
+      user: 'user1',
+      score: 15,
+      maxScore: 30, // 50%
+    },
+    {
+      user: 'user3',
+      score: 15,
+      maxScore: 25, // 60%
+    },
+    {
+      user: 'newUser',
+      score: 9,
+      maxScore: 18, // 45%
+    },
+  ];
 
-    it('When less than three results then add a new result to the top scores', () => {
-        expect(JSON.parse(localStorage.getItem('people'))).toBeNull();
-        peopleRanking.saveScore('user', 0, 100);
+  const expectedResultsWhenHigher = [
+    {
+      user: 'user1',
+      score: 15,
+      maxScore: 30, // 50%
+    },
+    {
+      user: 'user3',
+      score: 15,
+      maxScore: 25, // 60%
+    },
+    {
+      user: 'newUser',
+      score: 1,
+      maxScore: 1, // 100%
+    },
+  ];
 
-        expect(JSON.parse(localStorage.getItem('people'))).toEqual(expectedResultsWhenOnlyOne);
-    });
+  afterEach(() => {
+    localStorage.clear();
+  });
 
-    it('When there are three scores and a new one is equal to any of them then add the new result to the top scores instead of the lowest one', () => {
-        const vehiclesRanking = new Ranking('vehicles');
-        localStorage.setItem('vehicles', JSON.stringify(results));
+  it('When set wrong category name then exception will be thrown', () => {
+    expect(() => {
+      new Ranking('vehicle');
+    }).toThrow('"vehicle" mode is not valid!');
+  });
 
-        vehiclesRanking.saveScore('newUser', 9, 18); // 45%
+  it('When less than three results then add a new result to the top scores', () => {
+    expect(JSON.parse(localStorage.getItem('people'))).toBeNull();
+    peopleRanking.saveScore('user', 0, 100);
 
-        expect(JSON.parse(localStorage.getItem('vehicles'))).toEqual(expectedResultsWhenEqual);
-    });
+    expect(JSON.parse(localStorage.getItem('people'))).toEqual(
+      expectedResultsWhenOnlyOne,
+    );
+  });
 
-    it('When there are three scores and a new one is higher than any of them then add the new result to the top scores instead of the lowest one', () => {
-        const vehiclesRanking = new Ranking('vehicles');
-        localStorage.setItem('vehicles', JSON.stringify(results));
+  it('When there are three scores and a new one is equal to any of them then add the new result to the top scores instead of the lowest one', () => {
+    const vehiclesRanking = new Ranking('vehicles');
+    localStorage.setItem('vehicles', JSON.stringify(results));
 
-        vehiclesRanking.saveScore('newUser', 1, 1); // 100%
+    vehiclesRanking.saveScore('newUser', 9, 18); // 45%
 
-        expect(JSON.parse(localStorage.getItem('vehicles'))).toEqual(expectedResultsWhenHigher);
-    });
+    expect(JSON.parse(localStorage.getItem('vehicles'))).toEqual(
+      expectedResultsWhenEqual,
+    );
+  });
 
-    it('When there are three scores and a new one is less than all of them then do not add it to the top scores', () => {
-        const starshipsRanking = new Ranking('starships');
-        localStorage.setItem('starships', JSON.stringify(results));
+  it('When there are three scores and a new one is higher than any of them then add the new result to the top scores instead of the lowest one', () => {
+    const vehiclesRanking = new Ranking('vehicles');
+    localStorage.setItem('vehicles', JSON.stringify(results));
 
-        starshipsRanking.saveScore('newUser', 11, 25); // 44%
+    vehiclesRanking.saveScore('newUser', 1, 1); // 100%
 
-        expect(JSON.parse(localStorage.getItem('starships'))).toEqual(results);
-    });
+    expect(JSON.parse(localStorage.getItem('vehicles'))).toEqual(
+      expectedResultsWhenHigher,
+    );
+  });
 
-    it('Ranking saved in local storage should be returned', () => {
-        const starshipsRanking = new Ranking('starships');
-        localStorage.setItem('starships', JSON.stringify(results));
+  it('When there are three scores and a new one is less than all of them then do not add it to the top scores', () => {
+    const starshipsRanking = new Ranking('starships');
+    localStorage.setItem('starships', JSON.stringify(results));
 
-        expect(starshipsRanking.getScores()).toEqual(results);
-    });
+    starshipsRanking.saveScore('newUser', 11, 25); // 44%
 
-    it('When no score is saved in local storage then return an empty array', () => {
-        const starshipsRanking = new Ranking('starships');
-        expect(starshipsRanking.getScores()).toEqual([]);
-    });
-    
-    const expectedResultsWhenOnlyOne = [{
-        'user': 'user',
-        'score': 0,
-        'maxScore': 100
-    }];
+    expect(JSON.parse(localStorage.getItem('starships'))).toEqual(results);
+  });
 
-    const expectedResultsWhenEqual = [{
-        'user': 'user1',
-        'score': 15,
-        'maxScore': 30 // 50%
-    }, {
-        'user': 'user3',
-        'score': 15,
-        'maxScore': 25 // 60%
-    }, {
-        'user': 'newUser',
-        'score': 9,
-        'maxScore': 18 // 45%
-    }];
-    
-    const expectedResultsWhenHigher = [{
-        'user': 'user1',
-        'score': 15,
-        'maxScore': 30 // 50%
-    }, {
-        'user': 'user3',
-        'score': 15,
-        'maxScore': 25 // 60%
-    }, {
-        'user': 'newUser',
-        'score': 1,
-        'maxScore': 1 // 100%
-    }];
+  it('Ranking saved in local storage should be returned', () => {
+    const starshipsRanking = new Ranking('starships');
+    localStorage.setItem('starships', JSON.stringify(results));
+
+    expect(starshipsRanking.getScores()).toEqual(results);
+  });
+
+  it('When no score is saved in local storage then return an empty array', () => {
+    const starshipsRanking = new Ranking('starships');
+    expect(starshipsRanking.getScores()).toEqual([]);
+  });
 });

--- a/test/ranking.spec.js
+++ b/test/ranking.spec.js
@@ -1,0 +1,112 @@
+import {
+    Ranking
+} from '../src/app/Ranking';
+
+describe("Ranking's logic", () => {
+    const peopleRanking = new Ranking('people');
+
+    const results = [{
+        'user': 'user1',
+        'score': 15,
+        'maxScore': 30 // 50%
+    }, {
+        'user': 'user2',
+        'score': 18,
+        'maxScore': 40 // 45%
+    }, {
+        'user': 'user3',
+        'score': 15,
+        'maxScore': 25 // 60%
+    }];
+
+    afterEach(() => {
+        localStorage.clear();
+    });
+
+    it('When set wrong category name, exception will be thrown', () => {
+        expect(() => {
+            new Ranking('vehicle');
+        }).toThrow('"vehicle" mode is not valid!');
+    });
+
+    it('When new score is higher than or equal to at least one of top results, return true', () => {
+        localStorage.setItem('people', JSON.stringify(results));
+        const score = 9;
+        const maxScore = 18; // 45%
+
+        expect(peopleRanking._isHigherThanCurrentTop(score, maxScore)).toBeTruthy;
+    });
+
+    it('When new score is less than all of top results, return false', () => {
+        localStorage.setItem('people', JSON.stringify(results));
+        const score = 11;
+        const maxScore = 25; // 44%
+
+        expect(peopleRanking._isHigherThanCurrentTop(score, maxScore)).toBeFalsy;
+    });
+
+    it('When there are three results, return two best of them.', () => {
+        localStorage.setItem('people', JSON.stringify(results));
+        const bestResults = [{
+            'user': 'user1',
+            'score': 15,
+            'maxScore': 30 // 50%
+        }, {
+            'user': 'user3',
+            'score': 15,
+            'maxScore': 25 // 60%
+        }];
+
+        expect(peopleRanking._getTwoHighestResults()).toEqual(bestResults);
+    });
+
+    it('When less than three results, add a new result to the top scores', () => {
+        const savedResults = [{
+            'user': 'user',
+            'score': 0,
+            'maxScore': 100
+        }];
+        expect(JSON.parse(localStorage.getItem('people'))).toBeNull;
+        peopleRanking.saveScore('user', 0, 100);
+
+        expect(JSON.parse(localStorage.getItem('people'))).toEqual(savedResults);
+    });
+
+    it('When there are three scores and a new one is higher than or equal to any of them, add the new result to the top scores instead of the lowest one', () => {
+        const savedResults = [{
+            'user': 'user1',
+            'score': 15,
+            'maxScore': 30 // 50%
+        }, {
+            'user': 'user3',
+            'score': 15,
+            'maxScore': 25 // 60%
+        }, {
+            'user': 'newUser',
+            'score': 9,
+            'maxScore': 18 // 45%
+        }];
+        const vehiclesRanking = new Ranking('vehicles');
+        localStorage.setItem('vehicles', JSON.stringify(results));
+
+        vehiclesRanking.saveScore('newUser', 9, 18); // 45%
+
+        expect(JSON.parse(localStorage.getItem('vehicles'))).toEqual(savedResults);
+    });
+
+    it('When there are three scores and a new one is less than all of them, do not add it to the top scores', () => {
+        const starshipsRanking = new Ranking('starships');
+        localStorage.setItem('starships', JSON.stringify(results));
+
+        starshipsRanking.saveScore('newUser', 11, 25); // 44%
+
+        expect(JSON.parse(localStorage.getItem('starships'))).toEqual(results);
+    });
+
+    it('Ranking saved in local storage should be shown', () => {
+        const starshipsRanking = new Ranking('starships');
+        localStorage.setItem('starships', JSON.stringify(results));
+
+        expect(starshipsRanking.showRanking()).toEqual(results);
+    });
+});


### PR DESCRIPTION
- [x] Funkcja pozwalająca zapisać nick gracza i jego punktację w LocalStorage przeglądarki.
- [x] Funkcja pozwalająca odczytać z local storage ranking dla danego trybu gry.
- [x] Ranking powinien nie być globalny, ale oddzielny dla każdego trybu gry.
- [x] Działanie komponentu pokryte testami jednostkowymi.