### PR TITLE
Destroy comp function and tests

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -80,6 +80,8 @@ export const App = ({ options }) => {
     }),
     inside: mainContainer,
   });
+
+  odpFalse.destroy();
 };
 
 function renderNavMenu(parent, activeItemNr = 0, previousState = undefined) {

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -81,7 +81,7 @@ export const App = ({ options }) => {
     inside: mainContainer,
   });
 
-  odpFalse.destroy();
+  odpFalse.removeFromParent();
 };
 
 function renderNavMenu(parent, activeItemNr = 0, previousState = undefined) {

--- a/src/app/rendering.js
+++ b/src/app/rendering.js
@@ -8,6 +8,11 @@ export function render({ component, inside, withClasses }) {
   }
   const componentToRender = withClassList(component, withClasses);
   inside.appendChild(componentToRender);
+
+  componentToRender.destroy = () => {
+    inside.removeChild(componentToRender);
+  };
+
   return componentToRender;
 }
 

--- a/src/app/rendering.js
+++ b/src/app/rendering.js
@@ -9,7 +9,7 @@ export function render({ component, inside, withClasses }) {
   const componentToRender = withClassList(component, withClasses);
   inside.appendChild(componentToRender);
 
-  componentToRender.destroy = () => {
+  componentToRender.removeFromParent = () => {
     inside.removeChild(componentToRender);
   };
 

--- a/test/rendering.spec.js
+++ b/test/rendering.spec.js
@@ -54,6 +54,18 @@ describe('Render component (DOM element) inside another', () => {
     expect(renderedComponent).toHaveClass('with-class');
     expect(renderedComponent).toBe(aComponent);
   });
+
+  it('when destroy component , then parent component should be not have rendered component', () => {
+    const renderedComponent = render({
+      component: aComponent,
+      inside: aParent,
+      withClasses: 'with-class',
+    });
+
+    expect(aParent).toContainElement(renderedComponent);
+    renderedComponent.destroy();
+    expect(aParent).not.toContainElement(renderedComponent);
+  });
 });
 
 const aComponent = SampleDivWithText({

--- a/test/rendering.spec.js
+++ b/test/rendering.spec.js
@@ -55,7 +55,7 @@ describe('Render component (DOM element) inside another', () => {
     expect(renderedComponent).toBe(aComponent);
   });
 
-  it('when destroy component , then parent component should be not have rendered component', () => {
+  it('when destroy component, then parent component should not have rendered component inside', () => {
     const renderedComponent = render({
       component: aComponent,
       inside: aParent,
@@ -63,7 +63,7 @@ describe('Render component (DOM element) inside another', () => {
     });
 
     expect(aParent).toContainElement(renderedComponent);
-    renderedComponent.destroy();
+    renderedComponent.removeFromParent();
     expect(aParent).not.toContainElement(renderedComponent);
   });
 });


### PR DESCRIPTION
Dodano funkcję, której wywołanie spowoduje usunięcie komponentu z rodzica.
Wywoływane na każdym wyrenderowanym komponencie poprzez:
```renderedComponent.destroy();```